### PR TITLE
install onnxruntime-gpu or onnxruntime

### DIFF
--- a/install.py
+++ b/install.py
@@ -88,6 +88,18 @@ with open(req_file) as file:
             print(e)
             print(f"\nERROR: Failed to install {package} - ReActor won't start")
             raise e
+
+    if not is_installed('onnxruntime-gpu', '1.15.1', False) and not is_installed('onnxruntime', '1.15.1', False):
+        import torch.cuda as cuda
+        package = 'onnxruntime-gpu' if cuda.is_available() else 'onnxruntime'
+        try:
+            install_count += 1
+            run_pip(package)
+        except Exception as e:
+            print(e)
+            print(f"\nERROR: Failed to install {package} - ReActor won't start")
+            raise e
+
     if install_count > 0:
         print(f'\n--- PLEASE, RESTART the Server! ---\n')
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 insightface==0.7.3
 onnx>=1.14.0
-onnxruntime>=1.15.1
 opencv-python>=4.7.0.72


### PR DESCRIPTION
even though your extension onnxruntime (CPU) other extensions may wish to use onnxruntime-gpu
if some other extensions requires onnxruntime-gpu your extension will force install onnxruntime causing things to break

I belive the best practice currently is to install onnxruntime-gpu when cuda is available and onnxruntime when it not (not sure what to do with AMD)
as far as I'm aware I don't think this downside of installing the GPU version as you still run only on CPU version on GPU version

I'm not sure what you're doing with the https://github.com/Gourieff/sd-webui-reactor-force
I know you are using cuda over there but thats

that I have recently encountered
a couple of examples of extension that may be affected that I have encounter recently (including one of my own)
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/219
https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor (in my case I don't use GPU but I still install the GPU version when possible)
https://github.com/aria1th/sd-webui-nsfw-filter

I realize they most likely they are other extension that also force installs onnxruntime on top of onnxruntime-gpu
but one less is force install one less bug to deal with in the future