### PR TITLE
Add Masking option

### DIFF
--- a/scripts/entities/face.py
+++ b/scripts/entities/face.py
@@ -1,0 +1,147 @@
+import traceback
+
+import cv2
+import numpy as np
+from modules import images
+from PIL import Image
+
+
+from scripts.entities.rect import Point, Rect
+
+
+class Face:
+    def __init__(self, entire_image: np.ndarray, face_area: Rect, face_margin: float, face_size: int, upscaler: str):
+        self.face_area = face_area
+        self.center = face_area.center
+        left, top, right, bottom = face_area.to_square()
+
+        self.left, self.top, self.right, self.bottom = self.__ensure_margin(
+            left, top, right, bottom, entire_image, face_margin
+        )
+
+        self.width = self.right - self.left
+        self.height = self.bottom - self.top
+
+        self.image = self.__crop_face_image(entire_image, face_size, upscaler)
+        self.face_size = face_size
+        self.scale_factor = face_size / self.width
+        self.face_area_on_image = self.__get_face_area_on_image()
+        self.landmarks_on_image = self.__get_landmarks_on_image()
+
+    def __get_face_area_on_image(self):
+        left = int((self.face_area.left - self.left) * self.scale_factor)
+        top = int((self.face_area.top - self.top) * self.scale_factor)
+        right = int((self.face_area.right - self.left) * self.scale_factor)
+        bottom = int((self.face_area.bottom - self.top) * self.scale_factor)
+        return self.__clip_values(left, top, right, bottom)
+
+    def __get_landmarks_on_image(self):
+        landmarks = []
+        if self.face_area.landmarks is not None:
+            for landmark in self.face_area.landmarks:
+                landmarks.append(
+                    Point(
+                        int((landmark.x - self.left) * self.scale_factor),
+                        int((landmark.y - self.top) * self.scale_factor),
+                    )
+                )
+        return landmarks
+
+    def __crop_face_image(self, entire_image: np.ndarray, face_size: int, upscaler: str):
+        cropped = entire_image[self.top : self.bottom, self.left : self.right, :]
+        if upscaler:
+            return images.resize_image(0, Image.fromarray(cropped), face_size, face_size, upscaler)
+        else:
+            return Image.fromarray(cv2.resize(cropped, dsize=(face_size, face_size)))
+
+    def __ensure_margin(self, left: int, top: int, right: int, bottom: int, entire_image: np.ndarray, margin: float):
+        entire_height, entire_width = entire_image.shape[:2]
+
+        side_length = right - left
+        margin = min(min(entire_height, entire_width) / side_length, margin)
+        diff = int((side_length * margin - side_length) / 2)
+
+        top = top - diff
+        bottom = bottom + diff
+        left = left - diff
+        right = right + diff
+
+        if top < 0:
+            bottom = bottom - top
+            top = 0
+        if left < 0:
+            right = right - left
+            left = 0
+
+        if bottom > entire_height:
+            top = top - (bottom - entire_height)
+            bottom = entire_height
+        if right > entire_width:
+            left = left - (right - entire_width)
+            right = entire_width
+
+        return left, top, right, bottom
+
+    def get_angle(self) -> float:
+        landmarks = getattr(self.face_area, "landmarks", None)
+        if landmarks is None:
+            return 0
+
+        eye1 = getattr(landmarks, "eye1", None)
+        eye2 = getattr(landmarks, "eye2", None)
+        if eye2 is None or eye1 is None:
+            return 0
+
+        try:
+            dx = eye2.x - eye1.x
+            dy = eye2.y - eye1.y
+            if dx == 0:
+                dx = 1
+            angle = np.arctan(dy / dx) * 180 / np.pi
+
+            if dx < 0:
+                angle = (angle + 180) % 360
+            return angle
+        except Exception:
+            print(traceback.format_exc())
+            return 0
+
+    def rotate_face_area_on_image(self, angle: float):
+        center = [
+            (self.face_area_on_image[0] + self.face_area_on_image[2]) / 2,
+            (self.face_area_on_image[1] + self.face_area_on_image[3]) / 2,
+        ]
+
+        points = [
+            [self.face_area_on_image[0], self.face_area_on_image[1]],
+            [self.face_area_on_image[2], self.face_area_on_image[3]],
+        ]
+
+        angle = np.radians(angle)
+        rot_matrix = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+
+        points = np.array(points) - center
+        points = np.dot(points, rot_matrix.T)
+        points += center
+        left, top, right, bottom = (int(points[0][0]), int(points[0][1]), int(points[1][0]), int(points[1][1]))
+
+        left, right = (right, left) if left > right else (left, right)
+        top, bottom = (bottom, top) if top > bottom else (top, bottom)
+
+        width, height = right - left, bottom - top
+        if width < height:
+            left, right = left - (height - width) // 2, right + (height - width) // 2
+        elif height < width:
+            top, bottom = top - (width - height) // 2, bottom + (width - height) // 2
+        return self.__clip_values(left, top, right, bottom)
+
+    def __clip_values(self, *args):
+        result = []
+        for val in args:
+            if val < 0:
+                result.append(0)
+            elif val > self.face_size:
+                result.append(self.face_size)
+            else:
+                result.append(val)
+        return tuple(result)

--- a/scripts/entities/rect.py
+++ b/scripts/entities/rect.py
@@ -1,0 +1,78 @@
+from typing import Dict, NamedTuple, Tuple
+
+import numpy as np
+
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
+class Landmarks(NamedTuple):
+    eye1: Point
+    eye2: Point
+    nose: Point
+    mouth1: Point
+    mouth2: Point
+
+
+class Rect:
+    def __init__(
+        self,
+        left: int,
+        top: int,
+        right: int,
+        bottom: int,
+        tag: str = "face",
+        landmarks: Landmarks = None,
+        attributes: Dict[str, str] = {},
+    ) -> None:
+        self.tag = tag
+        self.left = left
+        self.top = top
+        self.right = right
+        self.bottom = bottom
+        self.center = int((right + left) / 2)
+        self.middle = int((top + bottom) / 2)
+        self.width = right - left
+        self.height = bottom - top
+        self.size = self.width * self.height
+        self.landmarks = landmarks
+        self.attributes = attributes
+
+    @classmethod
+    def from_ndarray(
+        cls,
+        face_box: np.ndarray,
+        tag: str = "face",
+        landmarks: Landmarks = None,
+        attributes: Dict[str, str] = {},
+    ) -> "Rect":
+        left, top, right, bottom, *_ = list(map(int, face_box))
+        return cls(left, top, right, bottom, tag, landmarks, attributes)
+
+    def to_tuple(self) -> Tuple[int, int, int, int]:
+        return self.left, self.top, self.right, self.bottom
+
+    def to_square(self):
+        left, top, right, bottom = self.to_tuple()
+
+        width = right - left
+        height = bottom - top
+
+        if width % 2 == 1:
+            right = right + 1
+            width = width + 1
+        if height % 2 == 1:
+            bottom = bottom + 1
+            height = height + 1
+
+        diff = int(abs(width - height) / 2)
+        if width > height:
+            top = top - diff
+            bottom = bottom + diff
+        else:
+            left = left - diff
+            right = right + diff
+
+        return left, top, right, bottom

--- a/scripts/inferencers/bisenet_mask_generator.py
+++ b/scripts/inferencers/bisenet_mask_generator.py
@@ -1,0 +1,88 @@
+from typing import List, Tuple
+
+import cv2
+import modules.shared as shared
+import numpy as np
+import torch
+from facexlib.parsing import init_parsing_model
+from facexlib.utils.misc import img2tensor
+from torchvision.transforms.functional import normalize
+from PIL import Image
+from scripts.inferencers.mask_generator import MaskGenerator
+from scripts.reactor_logger import logger
+
+class BiSeNetMaskGenerator(MaskGenerator):
+    def __init__(self) -> None:
+        self.mask_model = init_parsing_model(device=shared.device)
+
+    def name(self):
+        return "BiSeNet"
+
+    def generate_mask(
+        self,
+        face_image: np.ndarray,
+        face_area_on_image: Tuple[int, int, int, int],
+        affected_areas: List[str],
+        mask_size: int,
+        use_minimal_area: bool,
+        fallback_ratio: float = 0.25,
+        **kwargs,
+    ) -> np.ndarray:
+        original_face_image = face_image
+        face_image = face_image.copy()
+        face_image = face_image[:, :, ::-1]
+
+        if use_minimal_area:
+            face_image = MaskGenerator.mask_non_face_areas(face_image, face_area_on_image)
+
+        h, w, _ = face_image.shape
+
+        if w != 512 or h != 512:
+            rw = (int(w * (512 / w)) // 8) * 8
+            rh = (int(h * (512 / h)) // 8) * 8
+            face_image = cv2.resize(face_image, dsize=(rw, rh))
+
+        face_tensor = img2tensor(face_image.astype("float32") / 255.0, float32=True)
+        normalize(face_tensor, (0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True)
+        face_tensor = torch.unsqueeze(face_tensor, 0).to(shared.device)
+
+        with torch.no_grad():
+            face = self.mask_model(face_tensor)[0]
+        face = face.squeeze(0).cpu().numpy().argmax(0)
+        face = face.copy().astype(np.uint8)
+
+        mask = self.__to_mask(face, affected_areas)
+        
+        if mask_size > 0:
+            mask = cv2.dilate(mask, np.ones((5, 5), np.uint8), iterations=mask_size)
+        
+        if w != 512 or h != 512:
+            mask = cv2.resize(mask, dsize=(w, h))
+        
+        """if MaskGenerator.calculate_mask_coverage(mask) < fallback_ratio:
+            logger.info("Use fallback mask generator")
+            mask = self.fallback_mask_generator.generate_mask(
+                original_face_image, face_area_on_image, use_minimal_area=True
+            )"""
+       
+        return mask
+
+    def __to_mask(self, face: np.ndarray, affected_areas: List[str]) -> np.ndarray:
+        keep_face = "Face" in affected_areas
+        keep_neck = "Neck" in affected_areas
+        keep_hair = "Hair" in affected_areas
+        keep_hat = "Hat" in affected_areas
+
+        mask = np.zeros((face.shape[0], face.shape[1], 3), dtype=np.uint8)
+        num_of_class = np.max(face)
+        for i in range(1, num_of_class + 1):
+            index = np.where(face == i)
+            if i < 14 and keep_face:
+                mask[index[0], index[1], :] = [255, 255, 255]
+            elif i == 14 and keep_neck:
+                mask[index[0], index[1], :] = [255, 255, 255]
+            elif i == 17 and keep_hair:
+                mask[index[0], index[1], :] = [255, 255, 255]
+            elif i == 18 and keep_hat:
+                mask[index[0], index[1], :] = [255, 255, 255]
+        return mask

--- a/scripts/inferencers/mask_generator.py
+++ b/scripts/inferencers/mask_generator.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+
+class MaskGenerator(ABC):
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abstractmethod
+    def generate_mask(
+        self,
+        face_image: np.ndarray,
+        face_area_on_image: Tuple[int, int, int, int],
+        **kwargs,
+    ) -> np.ndarray:
+        pass
+
+    @staticmethod
+    def mask_non_face_areas(image: np.ndarray, face_area_on_image: Tuple[int, int, int, int]) -> np.ndarray:
+        left, top, right, bottom = face_area_on_image
+        image = image.copy()
+        image[:top, :] = 0
+        image[bottom:, :] = 0
+        image[:, :left] = 0
+        image[:, right:] = 0
+        return image
+
+    @staticmethod
+    def calculate_mask_coverage(mask: np.ndarray):
+        gray_mask = cv2.cvtColor(mask, cv2.COLOR_RGB2GRAY)
+        non_black_pixels = np.count_nonzero(gray_mask)
+        total_pixels = gray_mask.size
+        return non_black_pixels / total_pixels

--- a/scripts/reactor_faceswap.py
+++ b/scripts/reactor_faceswap.py
@@ -66,6 +66,8 @@ class FaceSwapScript(scripts.Script):
                     img = gr.Image(type="pil")
                     enable = gr.Checkbox(False, label="Enable", info=f"The Fast and Simple FaceSwap Extension - {version_flag}")
                     save_original = gr.Checkbox(False, label="Save Original", info="Save the original image(s) made before swapping; If you use \"img2img\" - this option will affect with \"Swap in generated\" only")
+                    mask_face = gr.Checkbox(False, label="Mask Faces", info="Attempt to mask only the faces and eliminate pixelation of the image around the contours.")
+
                     gr.Markdown("<br>")
                     gr.Markdown("Source Image (above):")
                     with gr.Row():
@@ -211,6 +213,7 @@ class FaceSwapScript(scripts.Script):
             source_hash_check,
             target_hash_check,
             device,
+            mask_face
         ]
 
 
@@ -264,6 +267,7 @@ class FaceSwapScript(scripts.Script):
         source_hash_check,
         target_hash_check,
         device,
+        mask_face
     ):
         self.enable = enable
         if self.enable:
@@ -291,6 +295,7 @@ class FaceSwapScript(scripts.Script):
             self.source_hash_check = source_hash_check
             self.target_hash_check = target_hash_check
             self.device = device
+            self.mask_face = mask_face
             if self.gender_source is None or self.gender_source == "No":
                 self.gender_source = 0
             if self.gender_target is None or self.gender_target == "No":
@@ -334,6 +339,7 @@ class FaceSwapScript(scripts.Script):
                             source_hash_check=self.source_hash_check,
                             target_hash_check=self.target_hash_check,
                             device=self.device,
+                            mask_face=mask_face
                         )
                         p.init_images[i] = result
                         # result_path = get_image_path(p.init_images[i], p.outpath_samples, "", p.all_seeds[i], p.all_prompts[i], "txt", p=p, suffix="-swapped")
@@ -385,6 +391,7 @@ class FaceSwapScript(scripts.Script):
                                 source_hash_check=self.source_hash_check,
                                 target_hash_check=self.target_hash_check,
                                 device=self.device,
+                                mask_face=self.mask_face
                             )
                             if result is not None and swapped > 0:
                                 result_images.append(result)
@@ -442,6 +449,7 @@ class FaceSwapScript(scripts.Script):
                     source_hash_check=self.source_hash_check,
                     target_hash_check=self.target_hash_check,
                     device=self.device,
+                    mask_face=self.mask_face
                 )
                 try:
                     pp = scripts_postprocessing.PostprocessedImage(result)
@@ -468,6 +476,8 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
                 with gr.Column():
                     img = gr.Image(type="pil")
                     enable = gr.Checkbox(False, label="Enable", info=f"The Fast and Simple FaceSwap Extension - {version_flag}")
+                    mask_face = gr.Checkbox(False, label="Mask Faces", info="Attempt to mask only the faces and eliminate pixelation of the image around the contours.")
+                    
                     gr.Markdown("Source Image (above):")
                     with gr.Row():
                         source_faces_index = gr.Textbox(
@@ -582,6 +592,7 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
             'gender_target': gender_target,
             'codeformer_weight': codeformer_weight,
             'device': device,
+            'mask_face':mask_face
         }
         return args
 
@@ -631,6 +642,7 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
             self.gender_target = args['gender_target']
             self.codeformer_weight = args['codeformer_weight']
             self.device = args['device']
+            self.mask_face = args['mask_face']
             if self.gender_source is None or self.gender_source == "No":
                 self.gender_source = 0
             if self.gender_target is None or self.gender_target == "No":
@@ -669,6 +681,7 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
                     source_hash_check=True,
                     target_hash_check=True,
                     device=self.device,
+                    mask_face=self.mask_face
                 )
                 try:
                     pp.info["ReActor"] = True

--- a/scripts/reactor_swapper.py
+++ b/scripts/reactor_swapper.py
@@ -481,7 +481,7 @@ def swap_face(
                 
                 if enhancement_options is not None and swapped > 0:
                     if mask_face and entire_mask_image is not None:
-                        enhance_image_and_mask(result_image, enhancement_options,Image.fromarray(target_img_orig),Image.fromarray(entire_mask_image).convert("L"))    
+                        result_image = enhance_image_and_mask(result_image, enhancement_options,Image.fromarray(target_img_orig),Image.fromarray(entire_mask_image).convert("L"))    
                     else:    
                         result_image = enhance_image(result_image, enhancement_options)
                 elif mask_face and entire_mask_image is not None and swapped > 0:

--- a/scripts/reactor_swapper.py
+++ b/scripts/reactor_swapper.py
@@ -2,11 +2,11 @@ import copy
 import os
 from dataclasses import dataclass
 from typing import List, Union
-
+from typing import Tuple
 import cv2
 import numpy as np
 from PIL import Image
-
+from insightface.app.common import Face as IFace
 import insightface
 
 from scripts.reactor_helpers import get_image_md5hash, get_Device


### PR DESCRIPTION
This adds a checkbox under the "Save Original" check box to configure the extension to detect face areas on the original image and create a mask that will be applied to the swapped image and merged to create the final image so that it will be more precise than a rectangle and avoid blurring of details surrounding faces caused by inswapper and codeformer.