### PR TITLE
Update reactor_globals.py to avoid error if last_device.txt is empty.

### DIFF
--- a/scripts/reactor_globals.py
+++ b/scripts/reactor_globals.py
@@ -23,6 +23,7 @@ if not os.path.exists(REACTOR_MODELS_PATH):
         os.makedirs(FACE_MODELS_PATH)
 
 def updateDevice():
+    device = "CUDA"
     try:
         LAST_DEVICE_PATH = os.path.join(BASE_PATH, "last_device.txt")
         with open(LAST_DEVICE_PATH) as f:


### PR DESCRIPTION
device is undefined if last_device.txt is empty, this avoids the error and assumes 'CUDA'.