### PR TITLE
Separate single and multiple sources with tabs

### DIFF
--- a/reactor_ui/reactor_main_ui.py
+++ b/reactor_ui/reactor_main_ui.py
@@ -85,16 +85,21 @@ def show(is_img2img: bool, show_br: bool = True, **msgs):
                 imgs_hash_clear.click(clear_faces_list,None,[progressbar_area])
             gr.Markdown("<br>", visible=show_br)
             with gr.Column(visible=True) as control_col_1:
-                gr.Markdown("<center>🔽🔽🔽 Single Image has priority when both Areas in use 🔽🔽🔽</center>")
                 with gr.Row():
-                    img = gr.Image(
-                        type="pil",
-                        label="Single Source Image",
-                    )
-                    imgs = gr.Files(
-                        label=f"Multiple Source Images{msgs['extra_multiple_source']}",
-                        file_types=["image"],
-                    )
+                    selected_tab = gr.Textbox('tab_single', visible=False)
+                    with gr.Tabs() as tab_single:
+                        with gr.Tab('Single'):
+                            img = gr.Image(
+                                type="pil",
+                                label="Single Source Image",
+                            )
+                        with gr.Tab('Multiple') as tab_multiple:
+                            imgs = gr.Files(
+                                label=f"Multiple Source Images{msgs['extra_multiple_source']}",
+                                file_types=["image"],
+                            )
+                    tab_single.select(fn=lambda: 'tab_single', inputs=[], outputs=[selected_tab])
+                    tab_multiple.select(fn=lambda: 'tab_multiple', inputs=[], outputs=[selected_tab])
             with gr.Column(visible=False) as control_col_3:
                 gr.Markdown("<span style='display:block;text-align:right;padding-right:3px;margin: -15px 0;font-size:1.1em'><sup>Clear Hash if you see the previous face was swapped instead of the new one</sup></span>")
                 with gr.Row():
@@ -189,4 +194,4 @@ def show(is_img2img: bool, show_br: bool = True, **msgs):
     # select_source.select(on_select_source,[save_original],[control_col_1,control_col_2,control_col_3,save_original,imgs_hash_clear],show_progress=False)
     select_source.select(on_select_source,None,[control_col_1,control_col_2,control_col_3,imgs_hash_clear],show_progress=False)
 
-    return img, imgs, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image
+    return img, imgs, selected_tab, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image

--- a/scripts/reactor_faceswap.py
+++ b/scripts/reactor_faceswap.py
@@ -70,7 +70,7 @@ class FaceSwapScript(scripts.Script):
             msgs: dict = {
                 "extra_multiple_source": "",
             }
-            img, imgs, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image = ui_main.show(is_img2img=is_img2img, **msgs)
+            img, imgs, selected_tab, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image = ui_main.show(is_img2img=is_img2img, **msgs)
             
             # TAB DETECTION
             det_thresh, det_maxnum = ui_detection.show()
@@ -116,7 +116,8 @@ class FaceSwapScript(scripts.Script):
             random_image,
             upscale_force,
             det_thresh,
-            det_maxnum
+            det_maxnum,
+            selected_tab,
         ]
 
 
@@ -186,7 +187,8 @@ class FaceSwapScript(scripts.Script):
         random_image,
         upscale_force,
         det_thresh,
-        det_maxnum
+        det_maxnum,
+        selected_tab,
     ):
         self.enable = enable
         if self.enable:
@@ -198,7 +200,10 @@ class FaceSwapScript(scripts.Script):
                 return
             
             global SWAPPER_MODELS_PATH
-            self.source = img
+            if selected_tab == "tab_single":
+                self.source = img
+            else:
+                self.source = None
             self.face_restorer_name = face_restorer_name
             self.upscaler_scale = upscaler_scale
             self.upscaler_visibility = upscaler_visibility
@@ -220,7 +225,10 @@ class FaceSwapScript(scripts.Script):
             self.select_source = select_source
             self.face_model = face_model
             self.source_folder = source_folder
-            self.source_imgs = imgs
+            if selected_tab == "tab_single":
+                self.source_imgs = None
+            else:
+                self.source_imgs = imgs
             self.random_image = random_image
             self.upscale_force = upscale_force
             self.det_thresh=det_thresh
@@ -502,7 +510,7 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
             msgs: dict = {
                 "extra_multiple_source": " | Сomparison grid as a result",
             }
-            img, imgs, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image = ui_main.show(is_img2img=False, show_br=False, **msgs)
+            img, imgs, selected_tab, select_source, face_model, source_folder, save_original, mask_face, source_faces_index, gender_source, faces_index, gender_target, face_restorer_name, face_restorer_visibility, codeformer_weight, swap_in_source, swap_in_generated, random_image = ui_main.show(is_img2img=False, show_br=False, **msgs)
             
             # TAB DETECTION
             det_thresh, det_maxnum = ui_detection.show()
@@ -544,6 +552,7 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
             'upscale_force': upscale_force,
             'det_thresh': det_thresh,
             'det_maxnum': det_maxnum,
+            'selected_tab': selected_tab,
         }
         return args
 
@@ -588,7 +597,10 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
                 return
 
             global SWAPPER_MODELS_PATH
-            self.source = args['img']
+            if args['selected_tab'] == "tab_single":
+                self.source = args['img']
+            else:
+                self.source = None
             self.face_restorer_name = args['face_restorer_name']
             self.upscaler_scale = args['upscaler_scale']
             self.upscaler_visibility = args['upscaler_visibility']
@@ -605,7 +617,10 @@ class FaceSwapScriptExtras(scripts_postprocessing.ScriptPostprocessing):
             self.select_source = args['select_source']
             self.face_model = args['face_model']
             self.source_folder = args['source_folder']
-            self.source_imgs = args['imgs']
+            if args['selected_tab'] == "tab_single":
+                self.source_imgs = None
+            else:
+                self.source_imgs = args['imgs']
             self.random_image = args['random_image']
             self.upscale_force = args['upscale_force']
             self.det_thresh = args['det_thresh']


### PR DESCRIPTION
As for me "🔽🔽🔽 Single Image has priority when both Areas in use 🔽🔽🔽" looks awful. Tabs are better

![Screenshot_20240321_124741](https://github.com/Gourieff/sd-webui-reactor/assets/33491867/a85c4b5e-8cb7-4da5-8098-6db20902f845)
