### PR TITLE
albumentations==1.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+albumentations==1.4.3
 insightface==0.7.3
 onnx>=1.14.0
 opencv-python>=4.7.0.72


### PR DESCRIPTION
recent Upstream package changes causes installing insightface break webui
- for details read this post https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15564

fix solution, install `albumentations==1.4.3` before `insightface`
this way pip won't auto install  the newest version `1.4.4`

note I did not specifically test this with this extension this PR is based off knowledge