### PR TITLE
Update install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,6 +1,6 @@
 import subprocess
 import os, sys
-from typing import Any
+from typing import Any, Optional
 import pkg_resources
 from tqdm import tqdm
 import urllib.request
@@ -13,7 +13,6 @@ except:
         from modules.paths import models_path
     except:
         models_path = os.path.abspath("models")
-
 
 BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -34,7 +33,7 @@ models_dir = os.path.join(models_path, "insightface")
 #             os.rmdir(models_dir_old)
 #         except Exception as e:
 #             print(f"OSError: {e}")
-            
+
 model_url = "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/inswapper_128.onnx"
 model_name = os.path.basename(model_url)
 model_path = os.path.join(models_dir, model_name)
@@ -45,9 +44,7 @@ def pip_install(*args):
 def pip_uninstall(*args):
     subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", *args])
 
-def is_installed (
-        package: str, version: str | None = None, strict: bool = True
-):
+def is_installed(package: str, version: Optional[str] = None, strict: bool = True) -> bool:
     has_package = None
     try:
         has_package = pkg_resources.get_distribution(package)
@@ -62,7 +59,7 @@ def is_installed (
     except Exception as e:
         print(f"Error: {e}")
         return False
-    
+
 def download(url, path):
     request = urllib.request.urlopen(url)
     total = int(request.headers.get('Content-Length', 0))
@@ -117,12 +114,12 @@ with open(req_file) as file:
                 last_device = "CPU"
         with open(os.path.join(BASE_PATH, "last_device.txt"), "w") as txt:
             txt.write(last_device)
-        if cuda_version is not None and float(cuda_version)>=12: # CU12
-            if not is_installed(ort,"1.17.1",False):
+        if cuda_version is not None and float(cuda_version) >= 12: # CU12
+            if not is_installed(ort, "1.17.1", False):
                 install_count += 1
                 pip_uninstall("onnxruntime", "onnxruntime-gpu")
-                pip_install(ort,"--extra-index-url","https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/")
-        elif not is_installed(ort,"1.16.1",False):
+                pip_install(ort, "--extra-index-url", "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/")
+        elif not is_installed(ort, "1.16.1", False):
             install_count += 1
             pip_install(ort, "-U")
     except Exception as e:
@@ -140,7 +137,7 @@ with open(req_file) as file:
             elif ">=" in package:
                 package_version = package.split('>=')[1]
                 strict = False
-            if not is_installed(package,package_version,strict):
+            if not is_installed(package, package_version, strict):
                 install_count += 1
                 pip_install(package)
         except Exception as e:


### PR DESCRIPTION
description for the error encountered when running the `install.py` script for the `sd-webui-reactor` extension, along with the solution provided:

---

### Error Description and Resolution for `install.py` in `sd-webui-reactor` Extension

#### Error Overview

When attempting to run the `install.py` script for the `sd-webui-reactor` extension within the Stable Diffusion WebUI environment, you encountered an error related to type annotations. The error message indicated an issue with the use of the union operator `|` in a type hint, which is not supported in the version of Python you are using.

#### Error Details

**Error Message:**
```plaintext
*** Error running install.py for extension /home/studio-lab-user/stable-diffusion-webui/extensions/sd-webui-reactor.
*** Command: "/home/studio-lab-user/.conda/envs/default/bin/python" "/home/studio-lab-user/stable-diffusion-webui/extensions/sd-webui-reactor/install.py"
*** Error code: 1
*** stderr: /home/studio-lab-user/stable-diffusion-webui/extensions/sd-webui-reactor/install.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
***   import pkg_resources
*** Traceback (most recent call last):
***   File "/home/studio-lab-user/stable-diffusion-webui/extensions/sd-webui-reactor/install.py", line 49, in <module>
***     package: str, version: str | None = None, strict: bool = True
*** TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

**Cause:**
The error is caused by using the `|` operator for type hinting optional types (i.e., `str | None`). This syntax is only supported in Python 3.10 and later. Using this syntax in an earlier version of Python results in a `TypeError`.

#### Solution

To resolve the error, the type annotation needs to be modified to be compatible with Python versions earlier than 3.10. Specifically, the `|` operator should be replaced with `Optional` from the `typing` module.

**Steps to Fix:**

1. **Update Type Annotation:**
   Modify the type hint in the `install.py` script to use `Optional[str]` instead of `str | None`.

   **Original Code:**
   ```python
   def is_installed(package: str, version: str | None = None, strict: bool = True) -> bool:
   ```

   **Modified Code:**
   ```python
   from typing import Optional

   def is_installed(package: str, version: Optional[str] = None, strict: bool = True) -> bool:
   ```

2. **Apply Changes:**
   Save the modified script and rerun the installation script.

**Updated Script:**
```python
import subprocess
import os, sys
from typing import Any, Optional
import pkg_resources
from tqdm import tqdm
import urllib.request
from packaging import version as pv

try:
    from modules.paths_internal import models_path
except:
    try:
        from modules.paths import models_path
    except:
        models_path = os.path.abspath("models")

BASE_PATH = os.path.dirname(os.path.realpath(__file__))

req_file = os.path.join(BASE_PATH, "requirements.txt")

models_dir = os.path.join(models_path, "insightface")

# DEPRECATED:
# models_dir_old = os.path.join(models_path, "roop")
# if os.path.exists(models_dir_old):
#     if not os.listdir(models_dir_old) and (not os.listdir(models_dir) or not os.path.exists(models_dir)):
#         os.rename(models_dir_old, models_dir)
#     else:
#         import shutil
#         for file in os.listdir(models_dir_old):
#             shutil.move(os.path.join(models_dir_old, file), os.path.join(models_dir, file))
#         try:
#             os.rmdir(models_dir_old)
#         except Exception as e:
#             print(f"OSError: {e}")

model_url = "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/inswapper_128.onnx"
model_name = os.path.basename(model_url)
model_path = os.path.join(models_dir, model_name)

def pip_install(*args):
    subprocess.run([sys.executable, "-m", "pip", "install", *args])

def pip_uninstall(*args):
    subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", *args])

def is_installed(package: str, version: Optional[str] = None, strict: bool = True) -> bool:
    has_package = None
    try:
        has_package = pkg_resources.get_distribution(package)
        if has_package is not None:
            installed_version = has_package.version
            if (installed_version != version and strict == True) or (pv.parse(installed_version) < pv.parse(version) and strict == False):
                return False
            else:
                return True
        else:
            return False
    except Exception as e:
        print(f"Error: {e}")
        return False

def download(url, path):
    request = urllib.request.urlopen(url)
    total = int(request.headers.get('Content-Length', 0))
    with tqdm(total=total, desc='Downloading...', unit='B', unit_scale=True, unit_divisor=1024) as progress:
        urllib.request.urlretrieve(url, path, reporthook=lambda count, block_size, total_size: progress.update(block_size))

if not os.path.exists(models_dir):
    os.makedirs(models_dir)

if not os.path.exists(model_path):
    download(model_url, model_path)

# print("ReActor preheating...", end=' ')

last_device = None
first_run = False
available_devices = ["CPU", "CUDA"]

try:
    last_device_log = os.path.join(BASE_PATH, "last_device.txt")
    with open(last_device_log) as f:
        last_device = f.readline().strip()
    if last_device not in available_devices:
        last_device = None
except:
    last_device = "CPU"
    first_run = True
    with open(os.path.join(BASE_PATH, "last_device.txt"), "w") as txt:
        txt.write(last_device)

with open(req_file) as file:
    install_count = 0
    ort = "onnxruntime-gpu"
    import torch
    cuda_version = None
    try:
        if torch.cuda.is_available():
            cuda_version = torch.version.cuda
            print(f"CUDA {cuda_version}")
            if first_run or last_device is None:
                last_device = "CUDA"
        elif torch.backends.mps.is_available() or hasattr(torch,'dml') or hasattr(torch,'privateuseone'):
            ort = "onnxruntime"
            # to prevent errors when ORT-GPU is installed but we want ORT instead:
            if first_run:
                pip_uninstall("onnxruntime", "onnxruntime-gpu")
            # just in case:
            if last_device == "CUDA" or last_device is None:
                last_device = "CPU"
        else:
            if last_device == "CUDA" or last_device is None:
                last_device = "CPU"
        with open(os.path.join(BASE_PATH, "last_device.txt"), "w") as txt:
            txt.write(last_device)
        if cuda_version is not None and float(cuda_version) >= 12: # CU12
            if not is_installed(ort, "1.17.1", False):
                install_count += 1
                pip_uninstall("onnxruntime", "onnxruntime-gpu")
                pip_install(ort, "--extra-index-url", "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/")
        elif not is_installed(ort, "1.16.1", False):
            install_count += 1
            pip_install(ort, "-U")
    except Exception as e:
        print(e)
        print(f"\nERROR: Failed to install {ort} - ReActor won't start")
        raise e
    # print(f"Device: {last_device}")
    strict = True
    for package in file:
        package_version = None
        try:
            package = package.strip()
            if "==" in package:
                package_version = package.split('==')[1]
            elif ">=" in package:
                package_version = package.split('>=')[1]
                strict = False
            if not is_installed(package, package_version, strict):
                install_count += 1
                pip_install(package)
        except Exception as e:
            print(e)
            print(f"\nERROR: Failed to install {package} - ReActor won't start")
            raise e
    if install_count > 0:
        print(f"""
        +---------------------------------+
        --- PLEASE, RESTART the Server! ---
        +---------------------------------+
        """)
```

### Running the Script

After applying these changes, execute the modified script with the following command:
```bash
"/home/studio-lab-user/.conda/envs/default/bin/python" "/home/studio-lab-user/stable-diffusion-webui/extensions/sd-webui-reactor/install.py"
```

This adjustment ensures compatibility with earlier versions of Python and resolves the type annotation error, allowing the script to run correctly and perform its intended tasks.

---